### PR TITLE
Tdx 29155-- Handle issue with mongodb cursors not being explicitly closed

### DIFF
--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationPolicyFailureEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationPolicyFailureEvent.java
@@ -2,11 +2,12 @@ package org.apereo.cas.support.events.authentication;
 
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationTransaction;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
 
 import lombok.Getter;
 import lombok.ToString;
-import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
+
 
 import java.util.Map;
 

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationPolicyFailureEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationPolicyFailureEvent.java
@@ -5,6 +5,8 @@ import org.apereo.cas.authentication.AuthenticationTransaction;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 import java.util.Map;
 
@@ -19,6 +21,7 @@ import java.util.Map;
 public class CasAuthenticationPolicyFailureEvent extends CasAuthenticationTransactionFailureEvent {
     private static final long serialVersionUID = 2208076621158767073L;
     private final Authentication authentication;
+    private final ClientInfoDTO clientInfoDTO;
 
     public CasAuthenticationPolicyFailureEvent(final Object source,
                                                final Map<String, Throwable> failures,
@@ -26,5 +29,6 @@ public class CasAuthenticationPolicyFailureEvent extends CasAuthenticationTransa
                                                final Authentication authentication) {
         super(source, failures, transaction.getCredentials());
         this.authentication = authentication;
+        this.clientInfoDTO = new ClientInfoDTO(ClientInfoHolder.getClientInfo());
     }
 }

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationTransactionFailureEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationTransactionFailureEvent.java
@@ -4,6 +4,8 @@ import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.support.events.AbstractCasEvent;
 
 import lombok.Getter;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 import java.util.Collection;
 import java.util.Map;
@@ -23,11 +25,14 @@ public class CasAuthenticationTransactionFailureEvent extends AbstractCasEvent {
 
     private final Collection<Credential> credential;
 
+    private final ClientInfoDTO clientInfoDTO;
+
     public CasAuthenticationTransactionFailureEvent(final Object source, final Map<String, Throwable> failures,
                                                     final Collection<Credential> credential) {
         super(source);
         this.failures = failures;
         this.credential = credential;
+        this.clientInfoDTO = new ClientInfoDTO(ClientInfoHolder.getClientInfo());
     }
 
     public Credential getCredential() {

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationTransactionFailureEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/CasAuthenticationTransactionFailureEvent.java
@@ -2,9 +2,9 @@ package org.apereo.cas.support.events.authentication;
 
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.support.events.AbstractCasEvent;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
 
 import lombok.Getter;
-import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 import java.util.Collection;

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/adaptive/CasRiskyAuthenticationDetectedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/adaptive/CasRiskyAuthenticationDetectedEvent.java
@@ -6,6 +6,8 @@ import org.apereo.cas.support.events.AbstractCasEvent;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 /**
  * This is {@link CasRiskyAuthenticationDetectedEvent}.
@@ -22,6 +24,7 @@ public class CasRiskyAuthenticationDetectedEvent extends AbstractCasEvent {
     private final Authentication authentication;
     private final RegisteredService service;
     private final Object score;
+    private final ClientInfoDTO clientInfoDTO;
 
     public CasRiskyAuthenticationDetectedEvent(final Object source, final Authentication authentication,
                                                final RegisteredService service,
@@ -30,5 +33,6 @@ public class CasRiskyAuthenticationDetectedEvent extends AbstractCasEvent {
         this.authentication = authentication;
         this.service = service;
         this.score = riskScore;
+        this.clientInfoDTO = new ClientInfoDTO(ClientInfoHolder.getClientInfo());
     }
 }

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/adaptive/CasRiskyAuthenticationDetectedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/authentication/adaptive/CasRiskyAuthenticationDetectedEvent.java
@@ -3,10 +3,10 @@ package org.apereo.cas.support.events.authentication.adaptive;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.support.events.AbstractCasEvent;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
 
 import lombok.Getter;
 import lombok.ToString;
-import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 /**

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/ClientInfoDTO.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/ClientInfoDTO.java
@@ -2,12 +2,18 @@ package org.apereo.cas.support.events.dao;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.apache.commons.lang.StringUtils;
-import org.apereo.inspektr.common.web.ClientInfoHolder;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.inspektr.common.web.ClientInfo;
+
+/**
+ * DTO to store client info.
+ *
+ * @author David Malia
+ * @since 6.5
+ */
 @Getter
 @AllArgsConstructor
-public class ClientInfoDTO implements java.io.Serializable{
+public class ClientInfoDTO implements java.io.Serializable {
     private static final long serialVersionUID = -4206712375316423417L;
 
     private final String clientIpAddress;
@@ -16,19 +22,19 @@ public class ClientInfoDTO implements java.io.Serializable{
     private final String userAgent;
     private final boolean initialized;
 
-   public ClientInfoDTO(ClientInfo clientInfo){
-       if(clientInfo != null && StringUtils.isNotEmpty(clientInfo.getClientIpAddress())){
-           this.clientIpAddress = clientInfo.getClientIpAddress();
-           this.serverIpAddress = clientInfo.getServerIpAddress();
-           this.userAgent = clientInfo.getUserAgent();
-           this.geoLocation = clientInfo.getGeoLocation();
-           this.initialized = true;
-       }else {
-           this.clientIpAddress = null;
-           this.serverIpAddress = null;
-           this.userAgent = null;
-           this.geoLocation = null;
-           this.initialized = false;
-       }
-   }
+    public ClientInfoDTO(final ClientInfo clientInfo) {
+        if (clientInfo != null && StringUtils.isNotEmpty(clientInfo.getClientIpAddress())) {
+            this.clientIpAddress = clientInfo.getClientIpAddress();
+            this.serverIpAddress = clientInfo.getServerIpAddress();
+            this.userAgent = clientInfo.getUserAgent();
+            this.geoLocation = clientInfo.getGeoLocation();
+            this.initialized = true;
+        } else {
+            this.clientIpAddress = null;
+            this.serverIpAddress = null;
+            this.userAgent = null;
+            this.geoLocation = null;
+            this.initialized = false;
+        }
+    }
 }

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/ClientInfoDTO.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/ClientInfoDTO.java
@@ -1,0 +1,34 @@
+package org.apereo.cas.support.events.dao;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang.StringUtils;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
+import org.apereo.inspektr.common.web.ClientInfo;
+@Getter
+@AllArgsConstructor
+public class ClientInfoDTO implements java.io.Serializable{
+    private static final long serialVersionUID = -4206712375316423417L;
+
+    private final String clientIpAddress;
+    private final String serverIpAddress;
+    private final String geoLocation;
+    private final String userAgent;
+    private final boolean initialized;
+
+   public ClientInfoDTO(ClientInfo clientInfo){
+       if(clientInfo != null && StringUtils.isNotEmpty(clientInfo.getClientIpAddress())){
+           this.clientIpAddress = clientInfo.getClientIpAddress();
+           this.serverIpAddress = clientInfo.getServerIpAddress();
+           this.userAgent = clientInfo.getUserAgent();
+           this.geoLocation = clientInfo.getGeoLocation();
+           this.initialized = true;
+       }else {
+           this.clientIpAddress = null;
+           this.serverIpAddress = null;
+           this.userAgent = null;
+           this.geoLocation = null;
+           this.initialized = false;
+       }
+   }
+}

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
@@ -1,11 +1,15 @@
 package org.apereo.cas.support.events.ticket;
 
-import lombok.Getter;
+
 import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 
+import lombok.Getter;
 import lombok.ToString;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
+
+
+
 
 
 /**

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
@@ -1,8 +1,11 @@
 package org.apereo.cas.support.events.ticket;
 
+import lombok.Getter;
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 
 import lombok.ToString;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 
 /**
@@ -14,9 +17,12 @@ import lombok.ToString;
  * @since 4.2
  */
 @ToString(callSuper = true)
+@Getter
 public class CasTicketGrantingTicketCreatedEvent extends AbstractCasTicketGrantingTicketEvent {
 
     private static final long serialVersionUID = -1862937393590213844L;
+
+    private final ClientInfoDTO clientInfoDTO;
 
     /**
      * Instantiates a new CAS sso session established event.
@@ -26,5 +32,6 @@ public class CasTicketGrantingTicketCreatedEvent extends AbstractCasTicketGranti
      */
     public CasTicketGrantingTicketCreatedEvent(final Object source, final TicketGrantingTicket ticketGrantingTicket) {
         super(source, ticketGrantingTicket);
+        this.clientInfoDTO = new ClientInfoDTO(ClientInfoHolder.getClientInfo());
     }
 }

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketDestroyedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketDestroyedEvent.java
@@ -1,9 +1,11 @@
 package org.apereo.cas.support.events.ticket;
 
+import org.apereo.cas.support.events.dao.ClientInfoDTO;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 /**
  * Concrete subclass of {@code AbstractCasEvent} representing single sign on session
@@ -19,6 +21,8 @@ public class CasTicketGrantingTicketDestroyedEvent extends AbstractCasTicketGran
 
     private static final long serialVersionUID = 584961303690286494L;
 
+    private final ClientInfoDTO clientInfoDTO;
+
     /**
      * Instantiates a new CAS sso session destroyed event.
      *
@@ -27,5 +31,6 @@ public class CasTicketGrantingTicketDestroyedEvent extends AbstractCasTicketGran
      */
     public CasTicketGrantingTicketDestroyedEvent(final Object source, final TicketGrantingTicket ticket) {
         super(source, ticket);
+        this.clientInfoDTO = new ClientInfoDTO(ClientInfoHolder.getClientInfo());
     }
 }

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasAuthenticationEventListener.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apereo.inspektr.common.web.ClientInfoHolder;
 
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
@@ -60,7 +59,7 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
 
     @Override
     public void handleCasTicketGrantingTicketCreatedEvent(final CasTicketGrantingTicketCreatedEvent event) throws Exception {
-        val dto = prepareCasEvent(event,event.getClientInfoDTO());
+        val dto = prepareCasEvent(event, event.getClientInfoDTO());
         dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime().toString());
         dto.putEventId(MessageSanitizationUtils.sanitize(event.getTicketGrantingTicket().getId()));
         dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
@@ -69,7 +68,7 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
 
     @Override
     public void handleCasTicketGrantingTicketDeletedEvent(final CasTicketGrantingTicketDestroyedEvent event) throws Exception {
-        val dto = prepareCasEvent(event,event.getClientInfoDTO());
+        val dto = prepareCasEvent(event, event.getClientInfoDTO());
         dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime().toString());
         dto.putEventId(MessageSanitizationUtils.sanitize(event.getTicketGrantingTicket().getId()));
         dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
@@ -78,7 +77,7 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
 
     @Override
     public void handleCasAuthenticationTransactionFailureEvent(final CasAuthenticationTransactionFailureEvent event) throws Exception {
-        val dto = prepareCasEvent(event,event.getClientInfoDTO());
+        val dto = prepareCasEvent(event, event.getClientInfoDTO());
         dto.setPrincipalId(event.getCredential().getId());
         dto.putEventId(CasAuthenticationPolicyFailureEvent.class.getSimpleName());
         this.casEventRepository.save(dto);
@@ -86,7 +85,7 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
 
     @Override
     public void handleCasAuthenticationPolicyFailureEvent(final CasAuthenticationPolicyFailureEvent event) throws Exception {
-        val dto = prepareCasEvent(event,event.getClientInfoDTO());
+        val dto = prepareCasEvent(event, event.getClientInfoDTO());
         dto.setPrincipalId(event.getAuthentication().getPrincipal().getId());
         dto.putEventId(CasAuthenticationPolicyFailureEvent.class.getSimpleName());
         this.casEventRepository.save(dto);
@@ -94,7 +93,7 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
 
     @Override
     public void handleCasRiskyAuthenticationDetectedEvent(final CasRiskyAuthenticationDetectedEvent event) throws Exception {
-        val dto = prepareCasEvent(event,event.getClientInfoDTO());
+        val dto = prepareCasEvent(event, event.getClientInfoDTO());
         dto.putEventId(event.getService().getName());
         dto.setPrincipalId(event.getAuthentication().getPrincipal().getId());
         this.casEventRepository.save(dto);

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/DefaultCasEventListenerTests.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/DefaultCasEventListenerTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.events;
 
+
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.DefaultAuthenticationTransaction;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
@@ -7,8 +8,6 @@ import org.apereo.cas.support.events.authentication.CasAuthenticationPolicyFailu
 import org.apereo.cas.support.events.authentication.CasAuthenticationTransactionFailureEvent;
 import org.apereo.cas.support.events.authentication.adaptive.CasRiskyAuthenticationDetectedEvent;
 import org.apereo.cas.support.events.config.CasCoreEventsConfiguration;
-import org.apereo.cas.support.events.dao.AbstractCasEventRepository;
-import org.apereo.cas.support.events.dao.CasEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.CollectionUtils;
@@ -34,16 +33,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import javax.security.auth.login.FailedLoginException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This is {@link DefaultCasEventListenerTests}.
@@ -52,24 +48,24 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 5.3.0
  */
 @SpringBootTest(classes = {
-    DefaultCasEventListenerTests.EventTestConfiguration.class,
-    CasCoreEventsConfiguration.class,
-    RefreshAutoConfiguration.class
+        DefaultCasEventListenerTests.EventTestConfiguration.class,
+        CasCoreEventsConfiguration.class,
+        RefreshAutoConfiguration.class
 })
 @Tag("Events")
 public class DefaultCasEventListenerTests {
+    private static final String REMOTE_ADDR_IP = "123.456.789.010";
+    private static final String LOCAL_ADDR_IP = "123.456.789.000";
+    private static final int NUM_TO_USE_IP1 = 50;
+    private static final int THREAD_POOL_SIZE = 50;
+    private static final int NUM_OF_REQUESTS = 500;
+
     @Autowired
     private ConfigurableApplicationContext applicationContext;
 
     @Autowired
     @Qualifier("casEventRepository")
     private CasEventRepository casEventRepository;
-    private static final String REMOTE_ADDR_IP = "123.456.789.010";
-    private static final String LOCAL_ADDR_IP = "123.456.789.000";
-
-    public static final int NUM_TO_USE_IP1 = 50;
-    public static final int THREAD_POOL_SIZE = 50;
-    public static final int NUM_OF_REQUESTS = 500;
 
 
     @BeforeEach
@@ -85,8 +81,8 @@ public class DefaultCasEventListenerTests {
     public void verifyCasAuthenticationWithNoClientInfo() {
         ClientInfoHolder.setClientInfo(null);
         val event = new CasAuthenticationTransactionFailureEvent(this,
-            CollectionUtils.wrap("error", new FailedLoginException()),
-            CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword()));
+                CollectionUtils.wrap("error", new FailedLoginException()),
+                CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword()));
         applicationContext.publishEvent(event);
         sleep();
         assertFalse(casEventRepository.load().findAny().isEmpty());
@@ -95,8 +91,8 @@ public class DefaultCasEventListenerTests {
     @Test
     public void verifyCasAuthenticationTransactionFailureEvent() {
         val event = new CasAuthenticationTransactionFailureEvent(this,
-            CollectionUtils.wrap("error", new FailedLoginException()),
-            CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword()));
+                CollectionUtils.wrap("error", new FailedLoginException()),
+                CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword()));
         applicationContext.publishEvent(event);
         sleep();
         assertFalse(casEventRepository.load().findAny().isEmpty());
@@ -114,10 +110,10 @@ public class DefaultCasEventListenerTests {
     @Test
     public void verifyCasAuthenticationPolicyFailureEvent() {
         val event = new CasAuthenticationPolicyFailureEvent(this,
-            CollectionUtils.wrap("error", new FailedLoginException()),
-            new DefaultAuthenticationTransaction(CoreAuthenticationTestUtils.getService(),
-                CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword())),
-            CoreAuthenticationTestUtils.getAuthentication());
+                CollectionUtils.wrap("error", new FailedLoginException()),
+                new DefaultAuthenticationTransaction(CoreAuthenticationTestUtils.getService(),
+                        CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword())),
+                CoreAuthenticationTestUtils.getAuthentication());
         applicationContext.publishEvent(event);
         sleep();
         assertFalse(casEventRepository.load().findAny().isEmpty());
@@ -126,9 +122,9 @@ public class DefaultCasEventListenerTests {
     @Test
     public void verifyCasRiskyAuthenticationDetectedEvent() {
         val event = new CasRiskyAuthenticationDetectedEvent(this,
-            CoreAuthenticationTestUtils.getAuthentication(),
-            CoreAuthenticationTestUtils.getRegisteredService(),
-            new Object());
+                CoreAuthenticationTestUtils.getAuthentication(),
+                CoreAuthenticationTestUtils.getRegisteredService(),
+                new Object());
         applicationContext.publishEvent(event);
         sleep();
         assertFalse(casEventRepository.load().findAny().isEmpty());
@@ -137,11 +133,12 @@ public class DefaultCasEventListenerTests {
     @Test
     public void verifyCasTicketGrantingTicketDestroyed() {
         val event = new CasTicketGrantingTicketDestroyedEvent(this,
-            new MockTicketGrantingTicket("casuser"));
+                new MockTicketGrantingTicket("casuser"));
         applicationContext.publishEvent(event);
         sleep();
         assertFalse(casEventRepository.load().findAny().isEmpty());
     }
+
     @Test
     public void verifyEventRepositoryHasOneEventOnly() {
         clearEventRepository();
@@ -149,7 +146,7 @@ public class DefaultCasEventListenerTests {
                 new MockTicketGrantingTicket("casuser"));
         applicationContext.publishEvent(event);
         sleep();
-        assertEquals("verify repo has 1 event",1,casEventRepository.load().collect(Collectors.toList()).size());
+        assertEquals(1, casEventRepository.load().collect(Collectors.toList()).size());
     }
 
     @Test
@@ -160,55 +157,56 @@ public class DefaultCasEventListenerTests {
         applicationContext.publishEvent(event);
         sleep();
         val result = casEventRepository.load().collect(Collectors.toList()).get(0).getClientIpAddress();
-        assertEquals(REMOTE_ADDR_IP ,result);
+        assertEquals(REMOTE_ADDR_IP, result);
     }
 
     @Test
-    public void verifyCasTicketGrantingTicketDestroyedHasClientInfoWithMultipleThreads() throws Exception{
+    public void verifyCasTicketGrantingTicketDestroyedHasClientInfoWithMultipleThreads() throws Exception {
         clearEventRepository();
         val threadPool = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
         val futureList = new ArrayList<Future<Integer>>();
         var expectedNumOfIp1 = 0;
-        for(var x = 0; x < NUM_OF_REQUESTS; x++){
-            if(shouldUseIp1(x)){
+        for (var x = 0; x < NUM_OF_REQUESTS; x++) {
+            if (shouldUseIp1(x)) {
                 expectedNumOfIp1++;
             }
-            futureList.add(threadPool.submit(new HttpServletRequestSimulation(x, shouldUseIp1(x),applicationContext)));
+            futureList.add(threadPool.submit(new HttpServletRequestSimulation(x, shouldUseIp1(x), applicationContext)));
         }
         var maxThread = -1;
-        for(var future: futureList){
-            var currentThread= future.get();
-            if(currentThread > maxThread){
+        for (var future : futureList) {
+            var currentThread = future.get();
+            if (currentThread > maxThread) {
                 maxThread = currentThread;
             }
         }
-        //let all the events catchup.
+
         Thread.sleep(5000L);
         val eventSize = casEventRepository.load().collect(Collectors.toList()).size();
         val numOfIp1s = casEventRepository.load().filter(e -> HttpServletRequestSimulation.IP1.equals(e.getClientIpAddress()))
                 .collect(Collectors.toList()).size();
-        assertEquals("size of events should be " + maxThread+1,maxThread+1 ,eventSize);
-        assertEquals("number of IP1s should be " + expectedNumOfIp1,expectedNumOfIp1,numOfIp1s);
+        assertEquals(maxThread + 1, eventSize);
+        assertEquals(expectedNumOfIp1, numOfIp1s);
 
 
     }
 
-    private static boolean shouldUseIp1(int x) {
+    private static boolean shouldUseIp1(final int x) {
         return x % NUM_TO_USE_IP1 == 0;
     }
 
-    private void clearEventRepository(){
-        SimpleCasEventRepository eventRepository = (SimpleCasEventRepository)  casEventRepository;
+    private void clearEventRepository() {
+        val eventRepository = (SimpleCasEventRepository) casEventRepository;
         eventRepository.clearEvents();
     }
 
     private void sleep() {
-        try{
+        try {
             Thread.sleep(20L);
-        }catch (Exception e){
-            throw new RuntimeException("thread interrupted",e);
+        } catch (final Exception e) {
+            throw new RuntimeException("thread interrupted", e);
         }
     }
+
     @TestConfiguration(value = "EventTestConfiguration", proxyBeanMethods = false)
     @EnableAsync
     public static class EventTestConfiguration implements AsyncConfigurer {
@@ -216,9 +214,10 @@ public class DefaultCasEventListenerTests {
         public CasEventRepository casEventRepository() {
             return new SimpleCasEventRepository(CasEventRepositoryFilter.noOp());
         }
+
         @Override
         public Executor getAsyncExecutor() {
-            ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+            val threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
             threadPoolTaskExecutor.initialize();
             return threadPoolTaskExecutor;
         }

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/DefaultCasEventListenerTests.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/DefaultCasEventListenerTests.java
@@ -30,10 +30,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.security.auth.login.FailedLoginException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -55,12 +60,19 @@ public class DefaultCasEventListenerTests {
     @Autowired
     @Qualifier("casEventRepository")
     private CasEventRepository casEventRepository;
+    private static final String REMOTE_ADDR_IP = "123.456.789.010";
+    private static final String LOCAL_ADDR_IP = "123.456.789.000";
+
+    public static final int NUM_TO_USE_IP1 = 50;
+    public static final int THREAD_POOL_SIZE = 50;
+    public static final int NUM_OF_REQUESTS = 500;
+
 
     @BeforeEach
     public void initialize() {
         val request = new MockHttpServletRequest();
-        request.setRemoteAddr("123.456.789.000");
-        request.setLocalAddr("123.456.789.000");
+        request.setRemoteAddr(REMOTE_ADDR_IP);
+        request.setLocalAddr(LOCAL_ADDR_IP);
         request.addHeader(HttpRequestUtils.USER_AGENT_HEADER, "test");
         ClientInfoHolder.setClientInfo(new ClientInfo(request));
     }
@@ -120,25 +132,66 @@ public class DefaultCasEventListenerTests {
         applicationContext.publishEvent(event);
         assertFalse(casEventRepository.load().findAny().isEmpty());
     }
+    @Test
+    public void verifyEventRepositoryHasOneEventOnly() {
+        clearEventRepository();
+        val event = new CasTicketGrantingTicketDestroyedEvent(this,
+                new MockTicketGrantingTicket("casuser"));
+        applicationContext.publishEvent(event);
+        assertEquals("verify repo has 1 event",1,casEventRepository.load().collect(Collectors.toList()).size());
+    }
 
+    @Test
+    public void verifyCasTicketGrantingTicketDestroyedHasClientInfo() {
+        clearEventRepository();
+        val event = new CasTicketGrantingTicketDestroyedEvent(this,
+                new MockTicketGrantingTicket("casuser"));
+        applicationContext.publishEvent(event);
+        val result = casEventRepository.load().collect(Collectors.toList()).get(0).getClientIpAddress();
+        assertEquals(REMOTE_ADDR_IP ,result);
+    }
+
+    @Test
+    public void verifyCasTicketGrantingTicketDestroyedHasClientInfoWithMultipleThreads() throws Exception{
+        clearEventRepository();
+        val threadPool = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+        val futureList = new ArrayList<Future<Integer>>();
+        var expectedNumOfIp1 = 0;
+        for(var x = 0; x < NUM_OF_REQUESTS; x++){
+            if(shouldUseIp1(x)){
+                expectedNumOfIp1++;
+            }
+            futureList.add(threadPool.submit(new HttpServletRequestSimulation(x, shouldUseIp1(x),applicationContext)));
+        }
+        var maxThread = -1;
+        for(var future: futureList){
+            var currentThread= future.get();
+            if(currentThread > maxThread){
+                maxThread = currentThread;
+            }
+        }
+        val eventSize = casEventRepository.load().collect(Collectors.toList()).size();
+        val numOfIp1s = casEventRepository.load().filter(e -> HttpServletRequestSimulation.IP1.equals(e.getClientIpAddress()))
+                .collect(Collectors.toList()).size();
+        assertEquals("size of events should be " + maxThread+1,maxThread+1 ,eventSize);
+        assertEquals("number of IP1s should be " + expectedNumOfIp1,expectedNumOfIp1,numOfIp1s);
+
+
+    }
+
+    private static boolean shouldUseIp1(int x) {
+        return x % NUM_TO_USE_IP1 == 0;
+    }
+
+    private void clearEventRepository(){
+        SimpleCasEventRepository eventRepository = (SimpleCasEventRepository)  casEventRepository;
+        eventRepository.clearEvents();
+    }
     @TestConfiguration(value = "EventTestConfiguration", proxyBeanMethods = false)
     public static class EventTestConfiguration {
         @Bean
         public CasEventRepository casEventRepository() {
-            return new AbstractCasEventRepository(CasEventRepositoryFilter.noOp()) {
-                private final Collection<CasEvent> events = new LinkedHashSet<>();
-
-                @Override
-                public CasEvent saveInternal(final CasEvent event) {
-                    events.add(event);
-                    return event;
-                }
-
-                @Override
-                public Stream<CasEvent> load() {
-                    return events.stream();
-                }
-            };
+            return new SimpleCasEventRepository(CasEventRepositoryFilter.noOp());
         }
     }
 }

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
@@ -48,8 +48,5 @@ public class HttpServletRequestSimulation implements Callable<Integer> {
         val tgt = new MockTicketGrantingTicket("casuser");
         val event = new CasTicketGrantingTicketCreatedEvent(this, tgt);
         applicationContext.publishEvent(event);
-        int x = 0;
-        System.out.println(x);
-
     }
 }

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
@@ -1,9 +1,11 @@
 package org.apereo.cas.support.events;
 
-import lombok.val;
+
+
 import org.apereo.cas.mock.MockTicketGrantingTicket;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.util.HttpRequestUtils;
+import lombok.val;
 import org.apereo.inspektr.common.web.ClientInfo;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -12,17 +14,32 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+/**
+ * A class to help simulate request threads.
+ *
+ * @author David Malia
+ * @since 6.5
+ */
 public class HttpServletRequestSimulation implements Callable<Integer> {
+    /**
+     * a different IP to test with.
+     */
+    public static final String IP2 = "123.45.67.89";
+    /**
+     * an IP to test with.
+     */
+    public static final String IP1 = "123.12.123.123";
 
     private final Integer threadNum;
     private final boolean useIP1;
 
     private ConfigurableApplicationContext applicationContext;
 
-    public static final String IP1 = "123.12.123.123";
-    public static final String IP2 = "123.45.67.89";
 
-    public HttpServletRequestSimulation(Integer threadNum, boolean useIP1, ConfigurableApplicationContext applicationContext) {
+
+
+
+    public HttpServletRequestSimulation(final Integer threadNum, final boolean useIP1, final ConfigurableApplicationContext applicationContext) {
         this.threadNum = threadNum;
         this.useIP1 = useIP1;
         this.applicationContext = applicationContext;
@@ -36,7 +53,7 @@ public class HttpServletRequestSimulation implements Callable<Integer> {
 
     private void postTGTCreatedEvent() {
         val request = new MockHttpServletRequest();
-        if(useIP1) {
+        if (useIP1) {
             request.setRemoteAddr(IP1);
             request.setLocalAddr(IP1);
         } else {

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/HttpServletRequestSimulation.java
@@ -1,0 +1,55 @@
+package org.apereo.cas.support.events;
+
+import lombok.val;
+import org.apereo.cas.mock.MockTicketGrantingTicket;
+import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
+import org.apereo.cas.util.HttpRequestUtils;
+import org.apereo.inspektr.common.web.ClientInfo;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+public class HttpServletRequestSimulation implements Callable<Integer> {
+
+    private final Integer threadNum;
+    private final boolean useIP1;
+
+    private ConfigurableApplicationContext applicationContext;
+
+    public static final String IP1 = "123.12.123.123";
+    public static final String IP2 = "123.45.67.89";
+
+    public HttpServletRequestSimulation(Integer threadNum, boolean useIP1, ConfigurableApplicationContext applicationContext) {
+        this.threadNum = threadNum;
+        this.useIP1 = useIP1;
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        postTGTCreatedEvent();
+        return threadNum;
+    }
+
+    private void postTGTCreatedEvent() {
+        val request = new MockHttpServletRequest();
+        if(useIP1) {
+            request.setRemoteAddr(IP1);
+            request.setLocalAddr(IP1);
+        } else {
+            request.setRemoteAddr(IP2);
+            request.setLocalAddr(IP2);
+        }
+        request.addHeader(HttpRequestUtils.USER_AGENT_HEADER, UUID.randomUUID().toString());
+        ClientInfoHolder.setClientInfo(new ClientInfo(request));
+        val tgt = new MockTicketGrantingTicket("casuser");
+        val event = new CasTicketGrantingTicketCreatedEvent(this, tgt);
+        applicationContext.publishEvent(event);
+        int x = 0;
+        System.out.println(x);
+
+    }
+}

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/SimpleCasEventRepository.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/SimpleCasEventRepository.java
@@ -1,0 +1,31 @@
+package org.apereo.cas.support.events;
+
+import org.apereo.cas.support.events.dao.AbstractCasEventRepository;
+import org.apereo.cas.support.events.dao.CasEvent;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+public class SimpleCasEventRepository extends AbstractCasEventRepository {
+    private final Map<String,CasEvent> events = new HashMap<>();
+
+    public SimpleCasEventRepository(CasEventRepositoryFilter eventRepositoryFilter) {
+        super(eventRepositoryFilter);
+    }
+
+    @Override
+    public CasEvent saveInternal(final CasEvent event) {
+        events.put(UUID.randomUUID().toString(),event);
+        return event;
+    }
+
+    @Override
+    public Stream<CasEvent> load() {
+        return events.values().stream();
+    }
+
+    public void clearEvents(){
+        events.clear();
+    }
+
+}

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/SimpleCasEventRepository.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/SimpleCasEventRepository.java
@@ -3,19 +3,26 @@ package org.apereo.cas.support.events;
 import org.apereo.cas.support.events.dao.AbstractCasEventRepository;
 import org.apereo.cas.support.events.dao.CasEvent;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
+/**
+ * A simple repostiory to facitilate testing.
+ * @author  David Malia
+ * @since 6.5
+ */
 public class SimpleCasEventRepository extends AbstractCasEventRepository {
-    private final Map<String,CasEvent> events = new HashMap<>();
+    private final Map<String, CasEvent> events = new HashMap<>();
 
-    public SimpleCasEventRepository(CasEventRepositoryFilter eventRepositoryFilter) {
+    public SimpleCasEventRepository(final CasEventRepositoryFilter eventRepositoryFilter) {
         super(eventRepositoryFilter);
     }
 
     @Override
     public CasEvent saveInternal(final CasEvent event) {
-        events.put(UUID.randomUUID().toString(),event);
+        events.put(UUID.randomUUID().toString(), event);
         return event;
     }
 
@@ -24,6 +31,9 @@ public class SimpleCasEventRepository extends AbstractCasEventRepository {
         return events.values().stream();
     }
 
+    /**
+     * remove events from event repository.
+     */
     public void clearEvents(){
         events.clear();
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Platform metadata for releases, POM generation, etc.
 ##################################################
 group=org.apereo.cas
-version=6.5.9.0.ksu.1
+version=6.5.9.0.ksu.2
 projectUrl=https://www.apereo.org/cas
 projectInceptionYear=2004
 projectScmUrl=scm:git@github.com:apereo/cas.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Platform metadata for releases, POM generation, etc.
 ##################################################
 group=org.apereo.cas
-version=6.5.10-SNAPSHOT
+version=6.5.9.0.ksu.1
 projectUrl=https://www.apereo.org/cas
 projectInceptionYear=2004
 projectScmUrl=scm:git@github.com:apereo/cas.git

--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -36,21 +37,22 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
 
     @Override
     public Stream<? extends CasEvent> load() {
-        return this.mongoTemplate.stream(new Query(), CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(new Query());
     }
 
     @Override
     public Stream<? extends CasEvent> load(final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
+
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
@@ -59,37 +61,45 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
                                                                   final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type)
-            .and(PRINCIPAL_ID_PARAM).is(principal)
-            .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+                .and(PRINCIPAL_ID_PARAM).is(principal)
+                .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
+        return getCasEventStream(query);
+
+    }
+
+    private Stream<CasEvent> getCasEventStream(final Query query) {
+        try (val stream = this.mongoTemplate.stream(query, CasEvent.class, this.collectionName)){
+            val list = stream.stream().collect(Collectors.toList());
+            return list.stream();
+        }
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String id) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(id));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String principal, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override


### PR DESCRIPTION
The MongoDBTemplate.stream() method returns a 'stream' of a mongodb cursor using a closable iterator.  Nothing before this pull request is explicitly closing the iterator, leaving it up to garbage collection.  Amazon DocumentDB has a fairly load cursor count (400) for R6.Xlarge instances, and we are running into it running a load test with 10 users with all the features of risk based authentication turned on.  This change explicitly closes the stream via try with resources.  This prevents the issue we are seeing.